### PR TITLE
 Fixed build of xr_alloc for x64 and x86 (simply disabled)

### DIFF
--- a/ogsr_engine/LuaJIT/src/xr_alloc.c
+++ b/ogsr_engine/LuaJIT/src/xr_alloc.c
@@ -7,16 +7,13 @@
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 
-typedef long (*PNTAVM)(HANDLE handle, void **addr, ULONG zbits,
-		       size_t *size, ULONG alloctype, ULONG prot);
-extern PNTAVM ntavm;
 /* Number of top bits of the lower 32 bits of an address that must be zero.
 ** Apparently 0 gives us full 64 bit addresses and 1 gives us the lower 2GB.
 */
-#define NTAVM_ZEROBITS		1
+#define NTAVM_ZEROBITS      1
 
-#define MAX_SIZE_T		(~(size_t)0)
-#define MFAIL			((void *)(MAX_SIZE_T))
+#define MAX_SIZE_T      (~(size_t)0)
+#define MFAIL           ((void *)(MAX_SIZE_T))
 
 // Луаджит выделяет память кусками, кратными 128К
 #define CHUNK_SIZE (128 * 1024)
@@ -35,47 +32,47 @@ void dump_map(void* ptr, size_t size, char c);
 
 void XR_INIT()
 {
-	if (inited)
-		return;
-	g_heap = NULL;
-	size_t size = CHUNK_SIZE * CHUNK_COUNT;
-	long st = ntavm(INVALID_HANDLE_VALUE, &g_heap, NTAVM_ZEROBITS, &size,
-	                MEM_RESERVE|MEM_COMMIT, PAGE_READWRITE);
+    if (inited)
+        return;
+    g_heap = NULL;
+    size_t size = CHUNK_SIZE * CHUNK_COUNT;
+    long st = ntavm(INVALID_HANDLE_VALUE, &g_heap, NTAVM_ZEROBITS, &size,
+                    MEM_RESERVE|MEM_COMMIT, PAGE_READWRITE);
 
-	for (int i = 0; i < CHUNK_COUNT; i++)
-		g_heapMap[i] = 'x';
-	g_heapMap[CHUNK_COUNT] = '\0';
-	g_firstFreeChunk = g_heapMap;
+    for (int i = 0; i < CHUNK_COUNT; i++)
+        g_heapMap[i] = 'x';
+    g_heapMap[CHUNK_COUNT] = '\0';
+    g_firstFreeChunk = g_heapMap;
 
-#ifdef DEBUG_MEM	
-	sprintf(buf, "XR_INIT create_block %p result=%X\r\n", g_heap, st);
-	OutputDebugString(buf);
+#ifdef DEBUG_MEM    
+    sprintf(buf, "XR_INIT create_block %p result=%X\r\n", g_heap, st);
+    OutputDebugString(buf);
 #endif
-	inited = 1;
+    inited = 1;
 }
 
 void* XR_MMAP(size_t size)
 {
 #ifdef DEBUG_MEM
-	sprintf(buf, "XR_MMAP(%Iu)", size);
-	OutputDebugString(buf);
+    sprintf(buf, "XR_MMAP(%Iu)", size);
+    OutputDebugString(buf);
 #endif
-	int chunks = size / CHUNK_SIZE;
-	char* s = find_free(chunks);
-	void* ptr = MFAIL;
-	if (s != NULL) {
-		ptr = (char*)g_heap + CHUNK_SIZE * (s - g_heapMap);
-		for (int i = 0; i < chunks; i++)
-			s[i] = 'a' + chunks - 1;
-		if (s == g_firstFreeChunk)
-			g_firstFreeChunk = find_free(1);
-	}
+    int chunks = size / CHUNK_SIZE;
+    char* s = find_free(chunks);
+    void* ptr = MFAIL;
+    if (s != NULL) {
+        ptr = (char*)g_heap + CHUNK_SIZE * (s - g_heapMap);
+        for (int i = 0; i < chunks; i++)
+            s[i] = 'a' + chunks - 1;
+        if (s == g_firstFreeChunk)
+            g_firstFreeChunk = find_free(1);
+    }
 #ifdef DEBUG_MEM
-	sprintf(buf, " ptr=%p chunks %d\r\n", ptr, chunks);
-	OutputDebugString(buf);
-	dump_map(ptr, size, 'U');
+    sprintf(buf, " ptr=%p chunks %d\r\n", ptr, chunks);
+    OutputDebugString(buf);
+    dump_map(ptr, size, 'U');
 #endif
-	return ptr;
+    return ptr;
 }
 
 // Судя по комментарию к CALL_MUNMAP, луаджит может объединять выделенные ему чанки
@@ -83,17 +80,17 @@ void* XR_MMAP(size_t size)
 void XR_DESTROY(void* ptr, size_t size)
 {
 #ifdef DEBUG_MEM
-	sprintf(buf, "XR_DESTROY(ptr=%p, size=%Iu)", ptr, size);
-	OutputDebugString(buf);
+    sprintf(buf, "XR_DESTROY(ptr=%p, size=%Iu)", ptr, size);
+    OutputDebugString(buf);
 #endif
-	char* s = g_heapMap + ((char*)ptr - (char*)g_heap) / CHUNK_SIZE;
-	int count = size / CHUNK_SIZE;
-	for (int i = 0; i < count; i++)
-		s[i] = 'x';
-	if (s < g_firstFreeChunk)
-		g_firstFreeChunk = s;
-#ifdef DEBUG_MEM	
-	dump_map(ptr, size, 'X');
+    char* s = g_heapMap + ((char*)ptr - (char*)g_heap) / CHUNK_SIZE;
+    int count = size / CHUNK_SIZE;
+    for (int i = 0; i < count; i++)
+        s[i] = 'x';
+    if (s < g_firstFreeChunk)
+        g_firstFreeChunk = s;
+#ifdef DEBUG_MEM    
+    dump_map(ptr, size, 'X');
 #endif
 }
 
@@ -101,39 +98,39 @@ void XR_DESTROY(void* ptr, size_t size)
 // Возвращает указатель на группу из heapMap или NULL, если найти не удалось
 char* find_free(int size)
 {
-	char* p = g_firstFreeChunk;
-	int count = 0;
-	while (*p != '\0') {
-		if (*p == 'x')
-			count++;
-		else
-			count = 0;
-		p++;
-		if (count == size)
-			return p - count;
-	}
-	return NULL;
+    char* p = g_firstFreeChunk;
+    int count = 0;
+    while (*p != '\0') {
+        if (*p == 'x')
+            count++;
+        else
+            count = 0;
+        p++;
+        if (count == size)
+            return p - count;
+    }
+    return NULL;
 }
 
-static 	char temp[1025];
+static  char temp[1025];
 void dump_map(void* ptr, size_t size, char c)
 {
 #ifdef DEBUG_MEM
-	OutputDebugString("heap:\r\n|-------|-------|-------|-------|-------|-------|-------|-------|-------|-------|-------|-------|-------|-------|-------|-------\r\n");
-	strcpy(temp, g_heapMap);
-	char *cur = temp + ((char*)ptr - (char*)g_heap) / CHUNK_SIZE;
-	for (int i = 0; i < size / CHUNK_SIZE; i++)
-		cur[i] = c;
-	
-	for (int i = 0; i < 8; i++)
-	{
-		char a = temp[i * 128 + 128];
-		temp[i * 128 + 128] = '\0';
-		OutputDebugString(temp + i * 128);
-		temp[i * 128 + 128] = a;
-		OutputDebugString("\r\n");
-	}
-	OutputDebugString("--------------------------------------------------------------------------------------------------------------------------------\r\n");
+    OutputDebugString("heap:\r\n|-------|-------|-------|-------|-------|-------|-------|-------|-------|-------|-------|-------|-------|-------|-------|-------\r\n");
+    strcpy(temp, g_heapMap);
+    char *cur = temp + ((char*)ptr - (char*)g_heap) / CHUNK_SIZE;
+    for (int i = 0; i < size / CHUNK_SIZE; i++)
+        cur[i] = c;
+    
+    for (int i = 0; i < 8; i++)
+    {
+        char a = temp[i * 128 + 128];
+        temp[i * 128 + 128] = '\0';
+        OutputDebugString(temp + i * 128);
+        temp[i * 128 + 128] = a;
+        OutputDebugString("\r\n");
+    }
+    OutputDebugString("--------------------------------------------------------------------------------------------------------------------------------\r\n");
 #endif
 }
 

--- a/ogsr_engine/LuaJIT/src/xr_alloc.c
+++ b/ogsr_engine/LuaJIT/src/xr_alloc.c
@@ -7,13 +7,16 @@
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 
+typedef long (*PNTAVM)(HANDLE handle, void **addr, ULONG zbits,
+		       size_t *size, ULONG alloctype, ULONG prot);
+extern PNTAVM ntavm;
 /* Number of top bits of the lower 32 bits of an address that must be zero.
 ** Apparently 0 gives us full 64 bit addresses and 1 gives us the lower 2GB.
 */
-#define NTAVM_ZEROBITS      1
+#define NTAVM_ZEROBITS		1
 
-#define MAX_SIZE_T      (~(size_t)0)
-#define MFAIL           ((void *)(MAX_SIZE_T))
+#define MAX_SIZE_T		(~(size_t)0)
+#define MFAIL			((void *)(MAX_SIZE_T))
 
 // Луаджит выделяет память кусками, кратными 128К
 #define CHUNK_SIZE (128 * 1024)
@@ -32,47 +35,47 @@ void dump_map(void* ptr, size_t size, char c);
 
 void XR_INIT()
 {
-    if (inited)
-        return;
-    g_heap = NULL;
-    size_t size = CHUNK_SIZE * CHUNK_COUNT;
-    long st = ntavm(INVALID_HANDLE_VALUE, &g_heap, NTAVM_ZEROBITS, &size,
-                    MEM_RESERVE|MEM_COMMIT, PAGE_READWRITE);
+	if (inited)
+		return;
+	g_heap = NULL;
+	size_t size = CHUNK_SIZE * CHUNK_COUNT;
+	long st = ntavm(INVALID_HANDLE_VALUE, &g_heap, NTAVM_ZEROBITS, &size,
+	                MEM_RESERVE|MEM_COMMIT, PAGE_READWRITE);
 
-    for (int i = 0; i < CHUNK_COUNT; i++)
-        g_heapMap[i] = 'x';
-    g_heapMap[CHUNK_COUNT] = '\0';
-    g_firstFreeChunk = g_heapMap;
+	for (int i = 0; i < CHUNK_COUNT; i++)
+		g_heapMap[i] = 'x';
+	g_heapMap[CHUNK_COUNT] = '\0';
+	g_firstFreeChunk = g_heapMap;
 
-#ifdef DEBUG_MEM    
-    sprintf(buf, "XR_INIT create_block %p result=%X\r\n", g_heap, st);
-    OutputDebugString(buf);
+#ifdef DEBUG_MEM	
+	sprintf(buf, "XR_INIT create_block %p result=%X\r\n", g_heap, st);
+	OutputDebugString(buf);
 #endif
-    inited = 1;
+	inited = 1;
 }
 
 void* XR_MMAP(size_t size)
 {
 #ifdef DEBUG_MEM
-    sprintf(buf, "XR_MMAP(%Iu)", size);
-    OutputDebugString(buf);
+	sprintf(buf, "XR_MMAP(%Iu)", size);
+	OutputDebugString(buf);
 #endif
-    int chunks = size / CHUNK_SIZE;
-    char* s = find_free(chunks);
-    void* ptr = MFAIL;
-    if (s != NULL) {
-        ptr = (char*)g_heap + CHUNK_SIZE * (s - g_heapMap);
-        for (int i = 0; i < chunks; i++)
-            s[i] = 'a' + chunks - 1;
-        if (s == g_firstFreeChunk)
-            g_firstFreeChunk = find_free(1);
-    }
+	int chunks = size / CHUNK_SIZE;
+	char* s = find_free(chunks);
+	void* ptr = MFAIL;
+	if (s != NULL) {
+		ptr = (char*)g_heap + CHUNK_SIZE * (s - g_heapMap);
+		for (int i = 0; i < chunks; i++)
+			s[i] = 'a' + chunks - 1;
+		if (s == g_firstFreeChunk)
+			g_firstFreeChunk = find_free(1);
+	}
 #ifdef DEBUG_MEM
-    sprintf(buf, " ptr=%p chunks %d\r\n", ptr, chunks);
-    OutputDebugString(buf);
-    dump_map(ptr, size, 'U');
+	sprintf(buf, " ptr=%p chunks %d\r\n", ptr, chunks);
+	OutputDebugString(buf);
+	dump_map(ptr, size, 'U');
 #endif
-    return ptr;
+	return ptr;
 }
 
 // Судя по комментарию к CALL_MUNMAP, луаджит может объединять выделенные ему чанки
@@ -80,17 +83,17 @@ void* XR_MMAP(size_t size)
 void XR_DESTROY(void* ptr, size_t size)
 {
 #ifdef DEBUG_MEM
-    sprintf(buf, "XR_DESTROY(ptr=%p, size=%Iu)", ptr, size);
-    OutputDebugString(buf);
+	sprintf(buf, "XR_DESTROY(ptr=%p, size=%Iu)", ptr, size);
+	OutputDebugString(buf);
 #endif
-    char* s = g_heapMap + ((char*)ptr - (char*)g_heap) / CHUNK_SIZE;
-    int count = size / CHUNK_SIZE;
-    for (int i = 0; i < count; i++)
-        s[i] = 'x';
-    if (s < g_firstFreeChunk)
-        g_firstFreeChunk = s;
-#ifdef DEBUG_MEM    
-    dump_map(ptr, size, 'X');
+	char* s = g_heapMap + ((char*)ptr - (char*)g_heap) / CHUNK_SIZE;
+	int count = size / CHUNK_SIZE;
+	for (int i = 0; i < count; i++)
+		s[i] = 'x';
+	if (s < g_firstFreeChunk)
+		g_firstFreeChunk = s;
+#ifdef DEBUG_MEM	
+	dump_map(ptr, size, 'X');
 #endif
 }
 
@@ -98,39 +101,39 @@ void XR_DESTROY(void* ptr, size_t size)
 // Возвращает указатель на группу из heapMap или NULL, если найти не удалось
 char* find_free(int size)
 {
-    char* p = g_firstFreeChunk;
-    int count = 0;
-    while (*p != '\0') {
-        if (*p == 'x')
-            count++;
-        else
-            count = 0;
-        p++;
-        if (count == size)
-            return p - count;
-    }
-    return NULL;
+	char* p = g_firstFreeChunk;
+	int count = 0;
+	while (*p != '\0') {
+		if (*p == 'x')
+			count++;
+		else
+			count = 0;
+		p++;
+		if (count == size)
+			return p - count;
+	}
+	return NULL;
 }
 
-static  char temp[1025];
+static 	char temp[1025];
 void dump_map(void* ptr, size_t size, char c)
 {
 #ifdef DEBUG_MEM
-    OutputDebugString("heap:\r\n|-------|-------|-------|-------|-------|-------|-------|-------|-------|-------|-------|-------|-------|-------|-------|-------\r\n");
-    strcpy(temp, g_heapMap);
-    char *cur = temp + ((char*)ptr - (char*)g_heap) / CHUNK_SIZE;
-    for (int i = 0; i < size / CHUNK_SIZE; i++)
-        cur[i] = c;
-    
-    for (int i = 0; i < 8; i++)
-    {
-        char a = temp[i * 128 + 128];
-        temp[i * 128 + 128] = '\0';
-        OutputDebugString(temp + i * 128);
-        temp[i * 128 + 128] = a;
-        OutputDebugString("\r\n");
-    }
-    OutputDebugString("--------------------------------------------------------------------------------------------------------------------------------\r\n");
+	OutputDebugString("heap:\r\n|-------|-------|-------|-------|-------|-------|-------|-------|-------|-------|-------|-------|-------|-------|-------|-------\r\n");
+	strcpy(temp, g_heapMap);
+	char *cur = temp + ((char*)ptr - (char*)g_heap) / CHUNK_SIZE;
+	for (int i = 0; i < size / CHUNK_SIZE; i++)
+		cur[i] = c;
+	
+	for (int i = 0; i < 8; i++)
+	{
+		char a = temp[i * 128 + 128];
+		temp[i * 128 + 128] = '\0';
+		OutputDebugString(temp + i * 128);
+		temp[i * 128 + 128] = a;
+		OutputDebugString("\r\n");
+	}
+	OutputDebugString("--------------------------------------------------------------------------------------------------------------------------------\r\n");
 #endif
 }
 

--- a/ogsr_engine/LuaJIT/src/xr_alloc.c
+++ b/ogsr_engine/LuaJIT/src/xr_alloc.c
@@ -2,19 +2,18 @@
 #include "lj_def.h"
 #include "lj_arch.h"
 
+#if LJ_64
+
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 
-typedef long (*PNTAVM)(HANDLE handle, void **addr, ULONG zbits,
-		       size_t *size, ULONG alloctype, ULONG prot);
-extern PNTAVM ntavm;
 /* Number of top bits of the lower 32 bits of an address that must be zero.
 ** Apparently 0 gives us full 64 bit addresses and 1 gives us the lower 2GB.
 */
-#define NTAVM_ZEROBITS		1
+#define NTAVM_ZEROBITS      1
 
-#define MAX_SIZE_T		(~(size_t)0)
-#define MFAIL			((void *)(MAX_SIZE_T))
+#define MAX_SIZE_T      (~(size_t)0)
+#define MFAIL           ((void *)(MAX_SIZE_T))
 
 // Луаджит выделяет память кусками, кратными 128К
 #define CHUNK_SIZE (128 * 1024)
@@ -33,47 +32,47 @@ void dump_map(void* ptr, size_t size, char c);
 
 void XR_INIT()
 {
-	if (inited)
-		return;
-	g_heap = NULL;
-	size_t size = CHUNK_SIZE * CHUNK_COUNT;
-	long st = ntavm(INVALID_HANDLE_VALUE, &g_heap, NTAVM_ZEROBITS, &size,
-	                MEM_RESERVE|MEM_COMMIT, PAGE_READWRITE);
+    if (inited)
+        return;
+    g_heap = NULL;
+    size_t size = CHUNK_SIZE * CHUNK_COUNT;
+    long st = ntavm(INVALID_HANDLE_VALUE, &g_heap, NTAVM_ZEROBITS, &size,
+                    MEM_RESERVE|MEM_COMMIT, PAGE_READWRITE);
 
-	for (int i = 0; i < CHUNK_COUNT; i++)
-		g_heapMap[i] = 'x';
-	g_heapMap[CHUNK_COUNT] = '\0';
-	g_firstFreeChunk = g_heapMap;
+    for (int i = 0; i < CHUNK_COUNT; i++)
+        g_heapMap[i] = 'x';
+    g_heapMap[CHUNK_COUNT] = '\0';
+    g_firstFreeChunk = g_heapMap;
 
-#ifdef DEBUG_MEM	
-	sprintf(buf, "XR_INIT create_block %p result=%X\r\n", g_heap, st);
-	OutputDebugString(buf);
+#ifdef DEBUG_MEM    
+    sprintf(buf, "XR_INIT create_block %p result=%X\r\n", g_heap, st);
+    OutputDebugString(buf);
 #endif
-	inited = 1;
+    inited = 1;
 }
 
 void* XR_MMAP(size_t size)
 {
 #ifdef DEBUG_MEM
-	sprintf(buf, "XR_MMAP(%Iu)", size);
-	OutputDebugString(buf);
+    sprintf(buf, "XR_MMAP(%Iu)", size);
+    OutputDebugString(buf);
 #endif
-	int chunks = size / CHUNK_SIZE;
-	char* s = find_free(chunks);
-	void* ptr = MFAIL;
-	if (s != NULL) {
-		ptr = (char*)g_heap + CHUNK_SIZE * (s - g_heapMap);
-		for (int i = 0; i < chunks; i++)
-			s[i] = 'a' + chunks - 1;
-		if (s == g_firstFreeChunk)
-			g_firstFreeChunk = find_free(1);
-	}
+    int chunks = size / CHUNK_SIZE;
+    char* s = find_free(chunks);
+    void* ptr = MFAIL;
+    if (s != NULL) {
+        ptr = (char*)g_heap + CHUNK_SIZE * (s - g_heapMap);
+        for (int i = 0; i < chunks; i++)
+            s[i] = 'a' + chunks - 1;
+        if (s == g_firstFreeChunk)
+            g_firstFreeChunk = find_free(1);
+    }
 #ifdef DEBUG_MEM
-	sprintf(buf, " ptr=%p chunks %d\r\n", ptr, chunks);
-	OutputDebugString(buf);
-	dump_map(ptr, size, 'U');
+    sprintf(buf, " ptr=%p chunks %d\r\n", ptr, chunks);
+    OutputDebugString(buf);
+    dump_map(ptr, size, 'U');
 #endif
-	return ptr;
+    return ptr;
 }
 
 // Судя по комментарию к CALL_MUNMAP, луаджит может объединять выделенные ему чанки
@@ -81,17 +80,17 @@ void* XR_MMAP(size_t size)
 void XR_DESTROY(void* ptr, size_t size)
 {
 #ifdef DEBUG_MEM
-	sprintf(buf, "XR_DESTROY(ptr=%p, size=%Iu)", ptr, size);
-	OutputDebugString(buf);
+    sprintf(buf, "XR_DESTROY(ptr=%p, size=%Iu)", ptr, size);
+    OutputDebugString(buf);
 #endif
-	char* s = g_heapMap + ((char*)ptr - (char*)g_heap) / CHUNK_SIZE;
-	int count = size / CHUNK_SIZE;
-	for (int i = 0; i < count; i++)
-		s[i] = 'x';
-	if (s < g_firstFreeChunk)
-		g_firstFreeChunk = s;
-#ifdef DEBUG_MEM	
-	dump_map(ptr, size, 'X');
+    char* s = g_heapMap + ((char*)ptr - (char*)g_heap) / CHUNK_SIZE;
+    int count = size / CHUNK_SIZE;
+    for (int i = 0; i < count; i++)
+        s[i] = 'x';
+    if (s < g_firstFreeChunk)
+        g_firstFreeChunk = s;
+#ifdef DEBUG_MEM    
+    dump_map(ptr, size, 'X');
 #endif
 }
 
@@ -99,38 +98,40 @@ void XR_DESTROY(void* ptr, size_t size)
 // Возвращает указатель на группу из heapMap или NULL, если найти не удалось
 char* find_free(int size)
 {
-	char* p = g_firstFreeChunk;
-	int count = 0;
-	while (*p != '\0') {
-		if (*p == 'x')
-			count++;
-		else
-			count = 0;
-		p++;
-		if (count == size)
-			return p - count;
-	}
-	return NULL;
+    char* p = g_firstFreeChunk;
+    int count = 0;
+    while (*p != '\0') {
+        if (*p == 'x')
+            count++;
+        else
+            count = 0;
+        p++;
+        if (count == size)
+            return p - count;
+    }
+    return NULL;
 }
 
-static 	char temp[1025];
+static  char temp[1025];
 void dump_map(void* ptr, size_t size, char c)
 {
 #ifdef DEBUG_MEM
-	OutputDebugString("heap:\r\n|-------|-------|-------|-------|-------|-------|-------|-------|-------|-------|-------|-------|-------|-------|-------|-------\r\n");
-	strcpy(temp, g_heapMap);
-	char *cur = temp + ((char*)ptr - (char*)g_heap) / CHUNK_SIZE;
-	for (int i = 0; i < size / CHUNK_SIZE; i++)
-		cur[i] = c;
-	
-	for (int i = 0; i < 8; i++)
-	{
-		char a = temp[i * 128 + 128];
-		temp[i * 128 + 128] = '\0';
-		OutputDebugString(temp + i * 128);
-		temp[i * 128 + 128] = a;
-		OutputDebugString("\r\n");
-	}
-	OutputDebugString("--------------------------------------------------------------------------------------------------------------------------------\r\n");
+    OutputDebugString("heap:\r\n|-------|-------|-------|-------|-------|-------|-------|-------|-------|-------|-------|-------|-------|-------|-------|-------\r\n");
+    strcpy(temp, g_heapMap);
+    char *cur = temp + ((char*)ptr - (char*)g_heap) / CHUNK_SIZE;
+    for (int i = 0; i < size / CHUNK_SIZE; i++)
+        cur[i] = c;
+    
+    for (int i = 0; i < 8; i++)
+    {
+        char a = temp[i * 128 + 128];
+        temp[i * 128 + 128] = '\0';
+        OutputDebugString(temp + i * 128);
+        temp[i * 128 + 128] = a;
+        OutputDebugString("\r\n");
+    }
+    OutputDebugString("--------------------------------------------------------------------------------------------------------------------------------\r\n");
 #endif
 }
+
+#endif

--- a/ogsr_engine/LuaJIT/src/xr_alloc.h
+++ b/ogsr_engine/LuaJIT/src/xr_alloc.h
@@ -1,6 +1,14 @@
 #ifndef _XR_POOL_H
 #define _XR_POOL_H
 
+#include <stddef.h>
+#include <windows.h>
+
+typedef long(*PNTAVM)(HANDLE handle, void **addr, ULONG zbits,
+    size_t *size, ULONG alloctype, ULONG prot);
+
+extern PNTAVM ntavm;
+
 // В сталкере x64 беда с luajit`ом - из-за того, что луаджит непременно требуется память из младших адресов,
 // на больших локациях луаджит не может выделить память, так как она уже занята под другие ресурсы игры.
 // Как вариант попробую выделить большой кусок памяти(128МБ) в начале игры и буду его потихоньку выдавать луаджиту


### PR DESCRIPTION
Moved body of xr_alloc.c under #if LJ_64
Moved extern PNTAVM ntavm; to xr_alloc.h