### PR TITLE
Fixed issue with dynamic zoom for attachable scopes.

### DIFF
--- a/ogsr_engine/xrGame/Weapon.cpp
+++ b/ogsr_engine/xrGame/Weapon.cpp
@@ -383,9 +383,11 @@ void CWeapon::Load		(LPCSTR section)
 	m_eSilencerStatus		 = (ALife::EWeaponAddonStatus)pSettings->r_s32(section,"silencer_status");
 	m_eGrenadeLauncherStatus = (ALife::EWeaponAddonStatus)pSettings->r_s32(section,"grenade_launcher_status");
 
-	m_bScopeDynamicZoom = !!READ_IF_EXISTS(pSettings, r_bool, section, "scope_dynamic_zoom", false);
 	m_bZoomEnabled = !!pSettings->r_bool(section,"zoom_enabled");
 	m_fZoomRotateTime = ROTATION_TIME;
+	m_bScopeDynamicZoom = false;
+	m_fScopeZoomFactor = 0;
+	m_fRTZoomFactor = 0;
 
 	UpdateZoomOffset();
 
@@ -591,9 +593,6 @@ BOOL CWeapon::net_Spawn		(CSE_Abstract* DC)
 
 	VERIFY((u32)iAmmoElapsed == m_magazine.size());
 	m_bAmmoWasSpawned		= false;
-
-	if ( m_bScopeDynamicZoom )
-		m_fRTZoomFactor = m_fScopeZoomFactor;
 
 	return bResult;
 }

--- a/ogsr_engine/xrGame/WeaponMagazined.cpp
+++ b/ogsr_engine/xrGame/WeaponMagazined.cpp
@@ -918,7 +918,6 @@ void CWeaponMagazined::InitAddons()
 	//////////////////////////////////////////////////////////////////////////
 	// Прицел
 	m_fIronSightZoomFactor = READ_IF_EXISTS(pSettings, r_float, cNameSect(), "ironsight_zoom_factor", 50.0f);
-	//
 	m_fSecondScopeZoomFactor = READ_IF_EXISTS(pSettings, r_float, cNameSect(), "second_scope_zoom_factor", m_fIronSightZoomFactor);
 	//
 	if(IsScopeAttached())
@@ -929,27 +928,28 @@ void CWeaponMagazined::InitAddons()
 			m_iScopeX	 = pSettings->r_s32(cNameSect(),"scope_x");
 			m_iScopeY	 = pSettings->r_s32(cNameSect(),"scope_y");
 
-			shared_str scope_tex_name;
-			scope_tex_name = pSettings->r_string(*m_sScopeName, "scope_texture");
 			m_fScopeZoomFactor = pSettings->r_float	(*m_sScopeName, "scope_zoom_factor");
 			m_bScopeDynamicZoom = !!READ_IF_EXISTS(pSettings, r_bool, *m_sScopeName, "scope_dynamic_zoom", false);
-			
+
+			shared_str scope_tex_name;
+			scope_tex_name = pSettings->r_string(*m_sScopeName, "scope_texture");
+
 			if(m_UIScope) xr_delete(m_UIScope);
 			m_UIScope = xr_new<CUIStaticItem>();
-
 			m_UIScope->Init(*scope_tex_name, "hud\\scope", 0, 0, alNone);
 
 		}
 		else if(m_eScopeStatus == ALife::eAddonPermanent)
 		{
-			m_fScopeZoomFactor = pSettings->r_float	(cNameSect(), "scope_zoom_factor");
+			m_fScopeZoomFactor = pSettings->r_float(cNameSect(), "scope_zoom_factor");
+			m_bScopeDynamicZoom = !!READ_IF_EXISTS(pSettings, r_bool, cNameSect(), "scope_dynamic_zoom", false);
+
 			shared_str scope_tex_name;
 			scope_tex_name = pSettings->r_string(cNameSect(), "scope_texture");
 
 			if(m_UIScope) xr_delete(m_UIScope);
 			m_UIScope = xr_new<CUIStaticItem>();
 			m_UIScope->Init(*scope_tex_name, "hud\\scope", 0, 0, alNone);
-
 		}
 	}
 	else
@@ -958,12 +958,19 @@ void CWeaponMagazined::InitAddons()
 		
 		if (IsZoomEnabled())
 		{
-			m_fIronSightZoomFactor = pSettings->r_float(cNameSect(), "scope_zoom_factor");
-			m_bScopeDynamicZoom = !!READ_IF_EXISTS(pSettings, r_bool, cNameSect(), "scope_dynamic_zoom", false);
+			m_fScopeZoomFactor = pSettings->r_float(cNameSect(), "scope_zoom_factor");
+			m_bScopeDynamicZoom = false;
+
+			// for weapon without any scope - scope_zoom_factor will overrider ironsight_zoom_factor
+			m_fIronSightZoomFactor = m_fScopeZoomFactor; 
 		}
 	}
 
-	
+	if (m_bScopeDynamicZoom)
+    {
+		m_fRTZoomFactor = m_fScopeZoomFactor;
+    }
+
 
 	if(IsSilencerAttached() && SilencerAttachable())
 	{		


### PR DESCRIPTION
Make sure to always init m_fRTZoomFactor, m_bScopeDynamicZoom and m_fScopeZoomFactor on InitAddons.

Иначе получалось, что если прицел ставить позже чем спаун - m_fRTZoomFactor был не инициализированный и при прицеливании получалось вот так вот  https://www.youtube.com/watch?v=dFuSXyL6OcU&feature=youtu.be

Так же, поскольку у Weapon есть из наследников только Нож и WeaponMagazined, но перенес все инициализации зума в InitAddons(), который вызывается всегда - при спауне, при загрузке и при аттаче\деаттаче аддонов.