### PR TITLE
Доработки по оружейке

### DIFF
--- a/ogsr_engine/build_config_defines.h
+++ b/ogsr_engine/build_config_defines.h
@@ -206,3 +206,6 @@
 // Выставлять для оружия состояние eSubstateIdleMoving при actor->is_actor_walking() || actor->is_actor_creeping() || actor->is_actor_crouching()
 // Включает анимацию anim_idle_moving
 //#define MORE_WPN_IDLE_MOVING_STATES
+
+// Цена оружия будет включать в себя стоимость установленных аддонов
+//#define WPN_COST_INCLUDE_ADDONS

--- a/ogsr_engine/build_config_defines.h
+++ b/ogsr_engine/build_config_defines.h
@@ -202,3 +202,7 @@
 
 // Включает раскраску предметов в окне торговца.
 //#define COLORIZE_OTHER_TRADE
+
+// Выставлять для оружия состояние eSubstateIdleMoving при actor->is_actor_walking() || actor->is_actor_creeping() || actor->is_actor_crouching()
+// Включает анимацию anim_idle_moving
+//#define MORE_WPN_IDLE_MOVING_STATES

--- a/ogsr_engine/xrGame/Level_Bullet_Manager.cpp
+++ b/ogsr_engine/xrGame/Level_Bullet_Manager.cpp
@@ -44,7 +44,7 @@ void SBullet::Init(const Fvector& position,
 {
 	flags._storage		= 0;
 	pos 				= position;
-	speed = max_speed	= starting_speed;
+	speed = max_speed	= starting_speed * cartridge.m_kSpeed;
 	VERIFY				(speed>0);
 
 	VERIFY(direction.magnitude()>0);

--- a/ogsr_engine/xrGame/Weapon.cpp
+++ b/ogsr_engine/xrGame/Weapon.cpp
@@ -1832,12 +1832,16 @@ u32 CWeapon::Cost() const
 {
 	u32 res = m_cost;
 	
+#ifdef WPN_COST_INCLUDE_ADDONS
+
 	if (GrenadeLauncherAttachable() && IsGrenadeLauncherAttached())
 		res += pSettings->r_float(GetGrenadeLauncherName(), "cost");
 	if (ScopeAttachable() && IsScopeAttached())
 		res += pSettings->r_float(GetScopeName(), "cost");
 	if (SilencerAttachable() && IsSilencerAttached())
 		res += pSettings->r_float(GetSilencerName(), "cost");
+
+#endif // WPN_COST_INCLUDE_ADDONS
 
 	return res;
 }

--- a/ogsr_engine/xrGame/Weapon.cpp
+++ b/ogsr_engine/xrGame/Weapon.cpp
@@ -868,8 +868,14 @@ u8 CWeapon::idle_state() {
     if ( actor->get_state() & mcSprint ) {
      return eSubstateIdleSprint;
     }
-    else if ( actor->is_actor_running() )
-      return eSubstateIdleMoving;
+	else {
+#ifdef MORE_WPN_IDLE_MOVING_STATES
+		if (actor->is_actor_running() || actor->is_actor_walking() || actor->is_actor_creeping() || actor->is_actor_crouching())
+#else
+		if (actor->is_actor_running())
+#endif
+			return eSubstateIdleMoving;
+	}
 
   return eIdle;
 }

--- a/ogsr_engine/xrGame/Weapon.cpp
+++ b/ogsr_engine/xrGame/Weapon.cpp
@@ -1827,6 +1827,21 @@ float CWeapon::Weight() const
 
 	return res;
 }
+
+u32 CWeapon::Cost() const
+{
+	u32 res = m_cost;
+	
+	if (GrenadeLauncherAttachable() && IsGrenadeLauncherAttached())
+		res += pSettings->r_float(GetGrenadeLauncherName(), "cost");
+	if (ScopeAttachable() && IsScopeAttached())
+		res += pSettings->r_float(GetScopeName(), "cost");
+	if (SilencerAttachable() && IsSilencerAttached())
+		res += pSettings->r_float(GetSilencerName(), "cost");
+
+	return res;
+}
+
 void CWeapon::Hide		()
 {
 	if(IsGameTypeSingle())

--- a/ogsr_engine/xrGame/Weapon.h
+++ b/ogsr_engine/xrGame/Weapon.h
@@ -274,6 +274,7 @@ public:
 			void			LoadZoomOffset		(LPCSTR section, LPCSTR prefix);
 
 	virtual float				Weight			() const;		
+	virtual u32					Cost			() const;
 
 public:
     virtual EHandDependence		HandDependence		()	const		{	return eHandDependence;}

--- a/ogsr_engine/xrGame/WeaponAmmo.cpp
+++ b/ogsr_engine/xrGame/WeaponAmmo.cpp
@@ -22,6 +22,7 @@ CCartridge::CCartridge()
 	m_kAirRes = 0.0f;
 	m_buckShot = 1;
 	m_impair = 1.f;
+	m_kSpeed = 1.f;
 
 	bullet_material_idx = u16(-1);
 }
@@ -30,12 +31,14 @@ void CCartridge::Load(LPCSTR section, u8 LocalAmmoType)
 {
 	m_ammoSect				= section;
 	m_LocalAmmoType			= LocalAmmoType;
+
 	m_kDist					= pSettings->r_float(section, "k_dist");
 	m_kDisp					= pSettings->r_float(section, "k_disp");
 	m_kHit					= pSettings->r_float(section, "k_hit");
 	m_kImpulse				= pSettings->r_float(section, "k_impulse");
 	m_kPierce				= pSettings->r_float(section, "k_pierce");
 	m_kAP					= READ_IF_EXISTS(pSettings, r_float, section, "k_ap", 0.0f);
+	m_kSpeed				= READ_IF_EXISTS(pSettings, r_float, section, "k_bullet_speed", 1.0f);
 	m_u8ColorID				= READ_IF_EXISTS(pSettings, r_u8, section, "tracer_color_ID", 0);
 	
 	if (pSettings->line_exist(section, "k_air_resistance"))
@@ -106,16 +109,19 @@ void CWeaponAmmo::Load(LPCSTR section)
 	m_kImpulse				= pSettings->r_float(section, "k_impulse");
 	m_kPierce				= pSettings->r_float(section, "k_pierce");
 	m_kAP					= READ_IF_EXISTS(pSettings, r_float, section, "k_ap", 0.0f);
+	m_kSpeed				= READ_IF_EXISTS(pSettings, r_float, section, "k_bullet_speed", 1.0f);
 	m_u8ColorID				= READ_IF_EXISTS(pSettings, r_u8, section, "tracer_color_ID", 0);
 
 	if (pSettings->line_exist(section, "k_air_resistance"))
 		m_kAirRes				=  pSettings->r_float(section, "k_air_resistance");
 	else
 		m_kAirRes				= pSettings->r_float(BULLET_MANAGER_SECTION, "air_resistance_k");
+
 	m_tracer				= !!pSettings->r_bool(section, "tracer");
 	m_buckShot				= pSettings->r_s32(section, "buck_shot");
 	m_impair				= pSettings->r_float(section, "impair");
 	fWallmarkSize			= pSettings->r_float(section,"wm_size");
+
 	R_ASSERT				(fWallmarkSize>0);
 
 	m_boxSize				= (u16)pSettings->r_s32(section, "box_size");

--- a/ogsr_engine/xrGame/WeaponAmmo.h
+++ b/ogsr_engine/xrGame/WeaponAmmo.h
@@ -15,7 +15,7 @@ public:
 		cfCanBeUnlimited		= (1<<2),
 		cfExplosive				= (1<<3),
 	};
-	float	m_kDist, m_kDisp, m_kHit, m_kImpulse, m_kPierce, m_kAP, m_kAirRes;
+	float	m_kDist, m_kDisp, m_kHit, m_kImpulse, m_kPierce, m_kAP, m_kAirRes, m_kSpeed;
 	int		m_buckShot;
 	float	m_impair;
 	float	fWallmarkSize;
@@ -54,7 +54,7 @@ public:
 	virtual u32						Cost				() const;
 	bool							Get					(CCartridge &cartridge);
 
-	float		m_kDist, m_kDisp, m_kHit, m_kImpulse, m_kPierce, m_kAP, m_kAirRes;
+	float		m_kDist, m_kDisp, m_kHit, m_kImpulse, m_kPierce, m_kAP, m_kAirRes, m_kSpeed;
 	int			m_buckShot;
 	float		m_impair;
 	float		fWallmarkSize;


### PR DESCRIPTION
1. В цену орудия будет учитываться цена аддонов на нем.
2. Анимация anim_idle_moving будет проигрываться и для состояний actor->is_actor_walking() || actor->is_actor_creeping() || actor->is_actor_crouching(). Под дефайном MORE_WPN_IDLE_MOVING_STATES
3. Добавлен параметр k_bullet_speed для секции амуниции. Позволяем менять скорость полета пули для определенного типа амуниции. По умолчанию 1 - потому не прятал.