### PR TITLE
Fixed a typo: *m_sScopeName > cNameSect() in InitAddons() method

### DIFF
--- a/ogsr_engine/xrGame/WeaponMagazined.cpp
+++ b/ogsr_engine/xrGame/WeaponMagazined.cpp
@@ -982,8 +982,8 @@ void CWeaponMagazined::InitAddons()
 			// for weapon without any scope - scope_zoom_factor will overrider ironsight_zoom_factor
 			m_fIronSightZoomFactor = m_fScopeZoomFactor; 
 
-			m_fSecondVP_FovFactor = READ_IF_EXISTS(pSettings, r_float, *m_sScopeName, "scope_lense_fov_factor", 0.0f);
-			m_fScopeInertionFactor = READ_IF_EXISTS(pSettings, r_float, *m_sScopeName, "scope_inertion_factor", m_fControlInertionFactor);
+			m_fSecondVP_FovFactor = READ_IF_EXISTS(pSettings, r_float, cNameSect(), "scope_lense_fov_factor", 0.0f);
+			m_fScopeInertionFactor = READ_IF_EXISTS(pSettings, r_float, cNameSect(), "scope_inertion_factor", m_fControlInertionFactor);
 		}
 		else 
 		{


### PR DESCRIPTION
Исправления к прошлому коммиту.
Для случая когда оружие без прицела - нужно читать параметры из секции самого оружия.