### PR TITLE
Исправление кривого скролла в dragdroplistex

### DIFF
--- a/ogsr_engine/xrGame/ui/UIDragDropListEx.cpp
+++ b/ogsr_engine/xrGame/ui/UIDragDropListEx.cpp
@@ -300,15 +300,21 @@ void CUIDragDropListEx::ReinitScroll()
 		m_vScrollBar->Show			( h1 > h2 );
 		m_vScrollBar->Enable		( h1 > h2 );
 
-		m_vScrollBar->SetRange		(0, _max(0,iFloor(h1-h2)) );
-//		m_vScrollBar->SetScrollPos	(0);
-		m_vScrollBar->SetStepSize	(CellSize().y/3);
-		m_vScrollBar->SetPageSize	(iFloor(GetWndSize().y/float(CellSize().y)));
+		m_vScrollBar->SetRange		(0, _max(0, iFloor(h1 - h2)));
+		m_vScrollBar->SetStepSize	(CellSize().y / 3);
+		m_vScrollBar->SetPageSize	(1);
+		
+		//m_vScrollBar->SetRange(0, _max(0, iFloor(h1 - h2)));
+		//m_vScrollBar->SetStepSize(CellSize().y / 3);
+		//m_vScrollBar->SetPageSize(iFloor(GetWndSize().y / float(CellSize().y)));
 
 		m_vScrollBar->SetScrollPos(m_vScrollBar->GetScrollPos());
 
 		m_container->SetWndPos		(0,0);
 }
+
+#include "../xr_3da/xr_input.h"
+#include "../level.h"
 
 bool CUIDragDropListEx::OnMouse(float x, float y, EUIMessages mouse_action)
 {
@@ -316,14 +322,26 @@ bool CUIDragDropListEx::OnMouse(float x, float y, EUIMessages mouse_action)
 
 	if(m_vScrollBar->IsShown())
 	{
+		bool with_shift = (Level().IR_GetKeyState(DIK_LSHIFT));
+
 		switch(mouse_action){
 		case WINDOW_MOUSE_WHEEL_DOWN:
 				m_vScrollBar->TryScrollInc();
+				if (with_shift) 
+				{
+					m_vScrollBar->TryScrollInc();
+					m_vScrollBar->TryScrollInc();
+				}
 				return true;
 				break;
 
 		case WINDOW_MOUSE_WHEEL_UP:
 				m_vScrollBar->TryScrollDec();
+				if (with_shift)
+				{
+					m_vScrollBar->TryScrollDec();
+					m_vScrollBar->TryScrollDec();
+				}
 				return true;
 				break;
 		}

--- a/ogsr_engine/xrGame/ui/UIDragDropListEx.cpp
+++ b/ogsr_engine/xrGame/ui/UIDragDropListEx.cpp
@@ -304,10 +304,6 @@ void CUIDragDropListEx::ReinitScroll()
 		m_vScrollBar->SetStepSize	(CellSize().y / 3);
 		m_vScrollBar->SetPageSize	(1);
 		
-		//m_vScrollBar->SetRange(0, _max(0, iFloor(h1 - h2)));
-		//m_vScrollBar->SetStepSize(CellSize().y / 3);
-		//m_vScrollBar->SetPageSize(iFloor(GetWndSize().y / float(CellSize().y)));
-
 		m_vScrollBar->SetScrollPos(m_vScrollBar->GetScrollPos());
 
 		m_container->SetWndPos		(0,0);

--- a/ogsr_engine/xrGame/ui/UIScrollBar.cpp
+++ b/ogsr_engine/xrGame/ui/UIScrollBar.cpp
@@ -303,7 +303,7 @@ bool CUIScrollBar::ScrollDec()
 
 bool CUIScrollBar::ScrollInc()
 {
-	if(m_iScrollPos<=(m_iMaxPos-m_iPageSize)){
+	if(m_iScrollPos<=(m_iMaxPos - m_iStepSize)){
 		SetScrollPos	(m_iScrollPos+m_iStepSize);
 		return true;
 	}


### PR DESCRIPTION
1. (простая часть) теперь если во время прокрутки мышкой в dragdroplistex зажать Shift - будет крутить в 3 раза быстрее.

2. (сложная часть) долго я искал, почему при определенных условиях прокрутка инвентаря "недокручивает" последний ряд даже при нормальном конфиге инвентаря. дело в том, что в UIDragDropListEx при инициализации сколлбара спутаны понятия высоты в пикселях и высоты в ячейках (строках). Нельзя указывать Range и StepSize в пикселях, а PageSize в строках. Потому как потом одно и другого будет вычитаться и получается полный бред. Поставил SetPageSize(1) и все стало работать нормально. А раньше правильно оно могло работать только тогда, если значения PageSize и StepSize совпадали численно.