### PR TITLE
A few more fixes to scroll managment in CUIDragDropListEx:

### DIFF
--- a/ogsr_engine/xrGame/ui/UIDragDropListEx.cpp
+++ b/ogsr_engine/xrGame/ui/UIDragDropListEx.cpp
@@ -306,7 +306,7 @@ void CUIDragDropListEx::ReinitScroll()
 		
 		m_vScrollBar->SetScrollPos(m_vScrollBar->GetScrollPos());
 
-		m_container->SetWndPos		(0,0);
+		m_container->SetWndPos(m_container->GetWndPos().x, float(-m_vScrollBar->GetScrollPos()));
 }
 
 #include "../xr_3da/xr_input.h"

--- a/ogsr_engine/xrGame/ui/UIScrollBar.cpp
+++ b/ogsr_engine/xrGame/ui/UIScrollBar.cpp
@@ -219,12 +219,12 @@ void CUIScrollBar::ClampByViewRect()
 	}
 }
 
-void CUIScrollBar::SetPosScrollFromView(float view_pos, float view_size, float view_offs)
+void CUIScrollBar::SetPosScrollFromView(float view_pos, int view_size, int view_offs)
 {
 	int scroll_size	= ScrollSize();
 	float pos			= view_pos-view_offs;
-	float work_size	= m_ScrollWorkArea-view_size;
-	SetScrollPosClamped	(work_size?iFloor(((pos/work_size)*(scroll_size) + m_iMinPos)):0);
+	int work_size = m_ScrollWorkArea - view_size;
+	SetScrollPosClamped	(work_size ? iFloor(((pos/work_size)*(scroll_size) + m_iMinPos)):0);
 }
 
 int CUIScrollBar::PosViewFromScroll(int view_size, int view_offs)
@@ -354,6 +354,15 @@ void CUIScrollBar::Draw()
 
 void CUIScrollBar::Refresh()
 {
-	SendMessage(m_ScrollBox, SCROLLBOX_MOVE, NULL);
+	if (m_bIsHorizontal)
+	{
+		if (GetMessageTarget())
+			GetMessageTarget()->SendMessage(this, SCROLLBAR_HSCROLL);
+	}
+	else
+	{
+		if (GetMessageTarget())
+			GetMessageTarget()->SendMessage(this, SCROLLBAR_VSCROLL);
+	}
 }
 

--- a/ogsr_engine/xrGame/ui/UIScrollBar.h
+++ b/ogsr_engine/xrGame/ui/UIScrollBar.h
@@ -37,7 +37,7 @@ protected:
 
 	u32				ScrollSize			(){return _max(1,m_iMaxPos-m_iMinPos-m_iPageSize+1);}
 	void			ClampByViewRect		();
-	void			SetPosScrollFromView(float view_pos, float view_width, float view_offs);
+	void			SetPosScrollFromView(float view_pos, int view_width, int view_offs);
 	int				PosViewFromScroll	(int view_size, int view_offs);
 	void			SetScrollPosClamped	(int iPos) { 
 														m_iScrollPos = iPos; 

--- a/ogsr_engine/xrGame/ui/uiinventorywnd2.cpp
+++ b/ogsr_engine/xrGame/ui/uiinventorywnd2.cpp
@@ -66,6 +66,8 @@ void CUIInventoryWnd::InitInventory()
 
 	m_pInv						= &pInvOwner->inventory();
 
+	int bag_scroll = m_pUIBagList->ScrollPos();
+
 	UIPropertiesBox.Hide		();
 	ClearAllLists				();
 	m_pMouseCapturer			= NULL;
@@ -170,6 +172,8 @@ void CUIInventoryWnd::InitInventory()
 	    m_pUIBagList->SetItem( itm );
 	  }
 	}
+
+	m_pUIBagList->SetScrollPos(bag_scroll);
 
 	UpdateWeight();
 


### PR DESCRIPTION
* Fix ScrollBar Refresh logic to not move content due to rounding error
* Fix issue when CUIDragDropListEx show wrong content due after auto grow in the middle of scroll
* Added logic to save main inventory position on updates