### PR TITLE
Правки по миникарте

### DIFF
--- a/ogsr_engine/xrGame/derived_client_classes.cpp
+++ b/ogsr_engine/xrGame/derived_client_classes.cpp
@@ -518,6 +518,7 @@ void CWeaponScript::script_register(lua_State *L)
 
 			.def_readonly("is_second_zoom_offset_enabled",			&CWeapon::is_second_zoom_offset_enabled)
 			.def("switch_scope"							,			&CWeapon::SwitchScope)
+			.def_readwrite("scope_inertion_factor"		,			&CWeapon::m_fScopeInertionFactor)
 
 			.property("ammo_elapsed"					,			&CWeapon::GetAmmoElapsed, &CWeapon::SetAmmoElapsed)
 			.property("const_deviation"					,			&CWeaponScript::FireDeviation)	// отклонение при стрельбе от целика (для непристрелляного оружия).

--- a/ogsr_engine/xrGame/map_location.cpp
+++ b/ogsr_engine/xrGame/map_location.cpp
@@ -337,7 +337,7 @@ void CMapLocation::UpdateSpot(CUICustomMap* map, CMapSpot* sp )
 		//update spot position
 		Fvector2 position = Position();
 
-		m_position_on_map =	map->ConvertRealToLocal(position, (map->Heading()) ? false : true);
+		m_position_on_map =	map->ConvertRealToLocal(position, true);
 
 		sp->SetWndPos(m_position_on_map);
 		Frect wnd_rect = sp->GetWndRect();


### PR DESCRIPTION
- Export scope_inertion_factor into scripts
- Fixed spots positions on minimap

Не знаю чем руководствовались люди когда при расчете положения точек на миникарте брали уловие (map->Heading()) ? false : true. В таком случае никогда не выполнялась коррекция для широкоформатиников и точки плавали по овалу. 