### PR TITLE
Работа с текстурами (поиск, замена)

### DIFF
--- a/ogsr_engine/xrGame/base_client_classes.h
+++ b/ogsr_engine/xrGame/base_client_classes.h
@@ -115,3 +115,13 @@ class CPatrolPathScript {
 add_to_type_list( CPatrolPathScript )
 #undef script_type_list
 #define script_type_list save_type_list( CPatrolPathScript )
+
+typedef class_exporter<CResourceManager> CResourceManagerScript;
+add_to_type_list(CResourceManagerScript)
+#undef script_type_list
+#define script_type_list save_type_list(CResourceManagerScript)
+
+typedef class_exporter<CTexture> CTextureScript;
+add_to_type_list(CTextureScript)
+#undef script_type_list
+#define script_type_list save_type_list(CTextureScript)

--- a/ogsr_engine/xr_3da/ParticleCustom.h
+++ b/ogsr_engine/xr_3da/ParticleCustom.h
@@ -8,6 +8,7 @@ public:
 	// geometry-format
 	ref_geom		geom;
 public:
+	IParticleCustom() { geom = NULL; } // alpet: предотвращение странного вылета
 	virtual 		~IParticleCustom	(){;}
 
     virtual void 	OnDeviceCreate		()=0;

--- a/ogsr_engine/xr_3da/ResourceManager.cpp
+++ b/ogsr_engine/xr_3da/ResourceManager.cpp
@@ -61,6 +61,38 @@ IBlender* CResourceManager::_FindBlender		(LPCSTR Name)
 	else						return I->second;
 }
 
+xr_vector<CTexture*> CResourceManager::_FindTexture(LPCSTR Name)
+{
+	R_ASSERT(Name && Name[0]);
+
+	string_path	filename;
+	strcpy_s(filename, Name); //. andy if (strext(Name)) *strext(Name)=0;
+	fix_texture_name(filename);
+
+	LPSTR N = LPSTR(filename);
+	char *ch = strstr(N, "*");
+
+	xr_vector<CTexture*> r;
+
+	if (NULL == ch) // no wildcard?
+	{
+		map_TextureIt I = m_textures.find(N);
+		if (I != m_textures.end())	
+			r.push_back(I->second);
+	}
+	else
+	{
+		// alpet: test for wildcard matching
+		ch[0] = 0; // remove *
+
+		for (map_TextureIt t = m_textures.begin(); t != m_textures.end(); t++)
+			if (strstr(t->second->cName.c_str(), N))
+				r.push_back(t->second);
+	}
+
+	return r;
+}
+
 void	CResourceManager::ED_UpdateBlender	(LPCSTR Name, IBlender* data)
 {
 	LPSTR N = LPSTR(Name);

--- a/ogsr_engine/xr_3da/ResourceManager.h
+++ b/ogsr_engine/xr_3da/ResourceManager.h
@@ -76,6 +76,8 @@ public:
 	void							_ParseList			(sh_list& dest, LPCSTR names);
 	IBlender*						_GetBlender			(LPCSTR Name);
 	IBlender* 						_FindBlender		(LPCSTR Name);
+	xr_vector<CTexture*>			_FindTexture		(LPCSTR Name);
+	CTexture*						_SetTexture			(CTexture* T);
 	void							_GetMemoryUsage		(u32& m_base, u32& c_base, u32& m_lmaps, u32& c_lmaps);
 	void							_DumpMemoryUsage	();
 //.	BOOL							_GetDetailTexture	(LPCSTR Name, LPCSTR& T, R_constant_setup* &M);

--- a/ogsr_engine/xr_3da/ResourceManager_Resources.cpp
+++ b/ogsr_engine/xr_3da/ResourceManager_Resources.cpp
@@ -493,6 +493,17 @@ CTexture* CResourceManager::_CreateTexture	(LPCSTR _Name)
 		return		T;
 	}
 }
+CTexture*	CResourceManager::_SetTexture(CTexture* T)
+{
+	LPSTR N = LPSTR(*T->cName);
+	map_TextureIt I = m_textures.find(N);
+	if (I != m_textures.end())	return	I->second;
+	else
+	{
+		m_textures.insert(mk_pair(N, T));
+		return		T;
+	}
+}
 void	CResourceManager::_DeleteTexture		(const CTexture* T)
 {
 	// DBG_VerifyTextures	();


### PR DESCRIPTION
Added methods to enumerate children of IRender_Visual
Added support of texture replacement in memory

Пример скрипта для использования:
```lua
local obj = db.actor:active_item()
local vis = obj:get_hud_visual()
if vis then
    log1("*********** child:")
    for i = 0, 15 do
       local c = vis:child(i) 
       if c then
            for ti = 0, 15 do    
                local tr = c:get_texture(ti)
                if tr then
                    local tname = tr:get_name()
                    log1("child=" .. i .. " tex_id=" .. ti .. " name=" .. tname .. " ref_count=" .. tr.ref_count)
                end
            end
       end
    end
end
```

```lua
log1("texture_find test for name: act\\act_arm_perchatka_cs")
local t1 = texture_find("act\\act_arm_perchatka_cs") -- возвращает таблицу: ключ имя текстуры, значение объект
if t1 then
    t1 = t1[ "act\\act_arm_perchatka_cs" ]
    log1("found, name=" .. t1:get_name())
    local ntname = "act\\act_arm_perchatka_cs_black"
    -- правильный порядок для обновления
    -- С этим способом замены текстура будет заменять везде где используется.
    t1:unload() -- выгрузить старую
    t1:set_name(ntname) -- указать новое имя
    t1:load()  -- загрузить новую
else 
    log1("texture_find test for name: act\\act_arm_perchatka_cs_black")
    local t2 = texture_find("act\\act_arm_perchatka_cs_black")
    if t2 then
        t2 = t2[ "act\\act_arm_perchatka_cs_black" ]
        log1("found, name=" .. t2:get_name())
        local ntname = "act\\act_arm_perchatka_cs"
        t2:unload()
        t2:set_name(ntname)
        t2:load()
    end
end
```

Поиск текстур по маске
```lua
log1("texture_find test for name: act\\act_arm_perchatka_cs*")
local t1 = texture_find("act\\act_arm_perchatka_cs*") -- возвращает таблицу: ключ имя текстуры, значение объект
if t1 then
    for n, t in pairs(t1) do
        log1("found, name=" .. t:get_name())
    end
end
```