### PR TITLE
Расширение серверный объектов.

### DIFF
--- a/ogsr_engine/COMMON_AI/xrServer_Objects_ALife_Items.cpp
+++ b/ogsr_engine/COMMON_AI/xrServer_Objects_ALife_Items.cpp
@@ -591,9 +591,7 @@ void CSE_ALifeItemWeaponMagazined::STATE_Read		(NET_Packet& P, u16 size)
 {
 	inherited::STATE_Read(P, size);
 
-	if (!P.r_eof()) {
-		m_u8CurFireMode = P.r_u8();
-	}
+	m_u8CurFireMode = P.r_u8();
 }
 void CSE_ALifeItemWeaponMagazined::STATE_Write		(NET_Packet& P)
 {
@@ -650,11 +648,9 @@ void CSE_ALifeItemWeaponMagazinedWGL::STATE_Read		(NET_Packet& P, u16 size)
 {
 	inherited::STATE_Read(P, size);
 
-	if (!P.r_eof()) {
-		ammo_type2 = P.r_u8();
-		a_elapsed2 = P.r_u16();
-		//Msg( "~~[%s][%s] update_read: m_bGrenadeMode: [%u], iAmmoElapsed2: [%u], m_ammoType2: [%u]", __FUNCTION__, this->name(), m_bGrenadeMode, a_elapsed2, ammo_type2 );
-	}
+	ammo_type2 = P.r_u8();
+	a_elapsed2 = P.r_u16();
+	//Msg( "~~[%s][%s] update_read: m_bGrenadeMode: [%u], iAmmoElapsed2: [%u], m_ammoType2: [%u]", __FUNCTION__, this->name(), m_bGrenadeMode, a_elapsed2, ammo_type2 );
 }
 
 void CSE_ALifeItemWeaponMagazinedWGL::STATE_Write		(NET_Packet& P)

--- a/ogsr_engine/COMMON_AI/xrServer_Objects_ALife_Items.cpp
+++ b/ogsr_engine/COMMON_AI/xrServer_Objects_ALife_Items.cpp
@@ -590,10 +590,16 @@ void CSE_ALifeItemWeaponMagazined::UPDATE_Write	(NET_Packet& P)
 void CSE_ALifeItemWeaponMagazined::STATE_Read		(NET_Packet& P, u16 size)
 {
 	inherited::STATE_Read(P, size);
+
+	if (!P.r_eof()) {
+		m_u8CurFireMode = P.r_u8();
+	}
 }
 void CSE_ALifeItemWeaponMagazined::STATE_Write		(NET_Packet& P)
 {
 	inherited::STATE_Write(P);
+
+	P.w_u8(m_u8CurFireMode);
 }
 
 void CSE_ALifeItemWeaponMagazined::FillProps			(LPCSTR pref, PropItemVec& items)
@@ -643,11 +649,21 @@ void CSE_ALifeItemWeaponMagazinedWGL::UPDATE_Write(NET_Packet& P)
 void CSE_ALifeItemWeaponMagazinedWGL::STATE_Read		(NET_Packet& P, u16 size)
 {
 	inherited::STATE_Read(P, size);
+
+	if (!P.r_eof()) {
+		ammo_type2 = P.r_u8();
+		a_elapsed2 = P.r_u16();
+		//Msg( "~~[%s][%s] update_read: m_bGrenadeMode: [%u], iAmmoElapsed2: [%u], m_ammoType2: [%u]", __FUNCTION__, this->name(), m_bGrenadeMode, a_elapsed2, ammo_type2 );
+	}
 }
 
 void CSE_ALifeItemWeaponMagazinedWGL::STATE_Write		(NET_Packet& P)
 {
 	inherited::STATE_Write(P);
+
+	P.w_u8(ammo_type2);
+	P.w_u16(a_elapsed2);
+	//Msg( "~~[%s][%s] update_write: m_bGrenadeMode: [%u], iAmmoElapsed2: [%u], m_ammoType2: [%u]", __FUNCTION__, this->name(), m_bGrenadeMode, a_elapsed2, ammo_type2 );
 }
 
 void CSE_ALifeItemWeaponMagazinedWGL::FillProps			(LPCSTR pref, PropItemVec& items)

--- a/ogsr_engine/COMMON_AI/xrServer_Objects_ALife_Items_script2.cpp
+++ b/ogsr_engine/COMMON_AI/xrServer_Objects_ALife_Items_script2.cpp
@@ -87,5 +87,6 @@ void CSE_ALifeItemWeaponMagazined::script_register(lua_State *L)
 			"cse_alife_item_weapon_magazined",
 			CSE_ALifeItemWeapon
 			)
+			.def_readwrite("current_fire_mode", &CSE_ALifeItemWeaponMagazined::m_u8CurFireMode)
 	];
 }

--- a/ogsr_engine/COMMON_AI/xrServer_Objects_ALife_Items_script3.cpp
+++ b/ogsr_engine/COMMON_AI/xrServer_Objects_ALife_Items_script3.cpp
@@ -21,5 +21,7 @@ void CSE_ALifeItemWeaponMagazinedWGL::script_register(lua_State *L)
 			"cse_alife_item_weapon_magazined_w_gl",
 			CSE_ALifeItemWeaponMagazined
 			)
+			.def_readwrite("ammo_type_2", &CSE_ALifeItemWeaponMagazinedWGL::ammo_type2)
+			.def_readwrite("ammo_elapsed_2", &CSE_ALifeItemWeaponMagazinedWGL::a_elapsed2)
 	];
 }

--- a/ogsr_engine/COMMON_AI/xrServer_Objects_ALife_Items_script3.cpp
+++ b/ogsr_engine/COMMON_AI/xrServer_Objects_ALife_Items_script3.cpp
@@ -23,5 +23,6 @@ void CSE_ALifeItemWeaponMagazinedWGL::script_register(lua_State *L)
 			)
 			.def_readwrite("ammo_type_2", &CSE_ALifeItemWeaponMagazinedWGL::ammo_type2)
 			.def_readwrite("ammo_elapsed_2", &CSE_ALifeItemWeaponMagazinedWGL::a_elapsed2)
+			.def_readwrite("gl_mode", &CSE_ALifeItemWeaponMagazinedWGL::m_bGrenadeMode)
 	];
 }

--- a/ogsr_engine/COMMON_AI/xrServer_Objects_ALife_script.cpp
+++ b/ogsr_engine/COMMON_AI/xrServer_Objects_ALife_script.cpp
@@ -96,6 +96,8 @@ void CSE_ALifeObject::script_register(lua_State *L)
 		.def("get_level_changer", &cse_object_cast<CSE_ALifeLevelChanger>)
 		.def("get_space_restrictor", &cse_object_cast<CSE_ALifeSpaceRestrictor>)
 		.def("get_weapon", &cse_object_cast<CSE_ALifeItemWeapon>)
+		.def("get_weapon_m", &cse_object_cast<CSE_ALifeItemWeaponMagazined>)
+		.def("get_weapon_gl", &cse_object_cast<CSE_ALifeItemWeaponMagazinedWGL>)
 		.def("get_trader", &cse_object_cast<CSE_ALifeTraderAbstract>)
 	];
 }

--- a/ogsr_engine/xrGame/derived_client_classes.cpp
+++ b/ogsr_engine/xrGame/derived_client_classes.cpp
@@ -546,6 +546,7 @@ void CWeaponScript::script_register(lua_State *L)
 			,
 			class_<CWeaponMagazinedWGrenade,			CWeaponMagazined>("CWeaponMagazinedWGrenade")
 			.def_readwrite("gren_mag_size"				,			&CWeaponMagazinedWGrenade::iMagazineSize2)			
+			.def("switch_gl"							,			&CWeaponMagazinedWGrenade::SwitchMode)
 			,
 			class_<CMissile, CInventoryItemObject>		("CMissile")
 			.def_readwrite("destroy_time"				,			&CMissile::m_dwDestroyTime)

--- a/ogsr_engine/xrGame/ui/UIScrollBar.cpp
+++ b/ogsr_engine/xrGame/ui/UIScrollBar.cpp
@@ -303,7 +303,7 @@ bool CUIScrollBar::ScrollDec()
 
 bool CUIScrollBar::ScrollInc()
 {
-	if(m_iScrollPos<=(m_iMaxPos - m_iStepSize)){
+	if(m_iScrollPos<m_iMaxPos){
 		SetScrollPos	(m_iScrollPos+m_iStepSize);
 		return true;
 	}

--- a/ogsr_engine/xr_3da/device.cpp
+++ b/ogsr_engine/xr_3da/device.cpp
@@ -248,15 +248,18 @@ void CRenderDevice::Run			()
 
 #ifndef ECO_RENDER
 				// FPS Lock
-				if (g_dwFPSlimit > 0)
+
+				static int menuFPSlimit = 61;
+				bool isMenuActive = IsMainMenuActive();
+
+				if (g_dwFPSlimit > 0 || isMenuActive)
 				{
 					static DWORD dwLastFrameTime = 0;
 					DWORD dwCurrentTime = timeGetTime();
-					if ((dwCurrentTime - dwLastFrameTime) < (1000 / g_dwFPSlimit))
+					if ((dwCurrentTime - dwLastFrameTime) < (1000 / (isMenuActive ? menuFPSlimit : g_dwFPSlimit)))
 						continue;
 					dwLastFrameTime = dwCurrentTime;
 				}
-
 #endif // !ECO_RENDER
 
 #ifdef DEDICATED_SERVER


### PR DESCRIPTION
Цель - дать возможность указать все основные параметры оружия через серверный объект при спауне. При спауне используется только методы STATE_Read\Write. Потому перенес туда новые свойства, все по аналогии с тем что уже было.

Added method get_weapon_m()/get_weapon_gl to access Weapon objects.
Added STATE_Read/STATE_Write for new properties to allow to override it during spawn.

Extend of CSE_ALifeItemWeaponMagazined:
* current_fire_mode
Extend of CSE_ALifeItemWeaponMagazinedWGL:
* ammo_type_2
* ammo_elapsed_2

