### PR TITLE
A different way of texture replacement

### DIFF
--- a/ogsr_engine/xrGame/base_client_classes_script.cpp
+++ b/ogsr_engine/xrGame/base_client_classes_script.cpp
@@ -495,22 +495,11 @@ LPCSTR script_texture_getname(CTexture *t)
 	return t->cName.c_str();
 }
 
-void script_texture_setname(CTexture *t, LPCSTR name)
-{
-	t->set_name(name);
-}
-
-void script_texture_load(CTexture *t)
-{
-	t->Preload();
-	t->Load();
-	Device.Resources->_SetTexture(t);
-}
-
-void script_texture_unload(CTexture *t)
+void script_texture_load(CTexture *t, LPCSTR name)
 {
 	t->Unload();
-	Device.Resources->_DeleteTexture(t);
+	t->Preload(name);
+	t->Load(name);
 }
 
 void CTextureScript::script_register(lua_State *L)
@@ -520,9 +509,7 @@ void CTextureScript::script_register(lua_State *L)
 		[
 			class_<CTexture>("CTexture")
 			.def("load", &script_texture_load)
-			.def("unload", &script_texture_unload)
 			.def("get_name", &script_texture_getname)
-			.def("set_name", &script_texture_setname)
 			.def_readonly("ref_count", &CTexture::dwReference)
 		];
 }
@@ -536,11 +523,9 @@ void CResourceManagerScript::script_register(lua_State *L)
 		// added by alpet
 		def("texture_find", &script_texture_find, raw<1>()),
 		def("texture_load", &script_texture_load),
-		def("texture_unload", &script_texture_unload),
 		def("texture_from_object", &script_object_get_texture),
 		def("texture_from_visual", &visual_get_texture),
-		def("texture_get_name", &script_texture_getname),
-		def("texture_set_name", &script_texture_setname)
+		def("texture_get_name", &script_texture_getname)
 	];
 }
 // alpet ======================== SCRIPT_TEXTURE_CONTROL END =========== 

--- a/ogsr_engine/xr_3da/ResourceManager.h
+++ b/ogsr_engine/xr_3da/ResourceManager.h
@@ -77,7 +77,6 @@ public:
 	IBlender*						_GetBlender			(LPCSTR Name);
 	IBlender* 						_FindBlender		(LPCSTR Name);
 	xr_vector<CTexture*>			_FindTexture		(LPCSTR Name);
-	CTexture*						_SetTexture			(CTexture* T);
 	void							_GetMemoryUsage		(u32& m_base, u32& c_base, u32& m_lmaps, u32& c_lmaps);
 	void							_DumpMemoryUsage	();
 //.	BOOL							_GetDetailTexture	(LPCSTR Name, LPCSTR& T, R_constant_setup* &M);

--- a/ogsr_engine/xr_3da/ResourceManager_Resources.cpp
+++ b/ogsr_engine/xr_3da/ResourceManager_Resources.cpp
@@ -493,17 +493,7 @@ CTexture* CResourceManager::_CreateTexture	(LPCSTR _Name)
 		return		T;
 	}
 }
-CTexture*	CResourceManager::_SetTexture(CTexture* T)
-{
-	LPSTR N = LPSTR(*T->cName);
-	map_TextureIt I = m_textures.find(N);
-	if (I != m_textures.end())	return	I->second;
-	else
-	{
-		m_textures.insert(mk_pair(N, T));
-		return		T;
-	}
-}
+
 void	CResourceManager::_DeleteTexture		(const CTexture* T)
 {
 	// DBG_VerifyTextures	();

--- a/ogsr_engine/xr_3da/SH_Texture.cpp
+++ b/ogsr_engine/xr_3da/SH_Texture.cpp
@@ -149,11 +149,21 @@ void CTexture::Preload	()
 //		Msg	("mid[%f] : %s",m_material,*cName);
 	}
 */
-	m_bumpmap = Device.Resources->m_textures_description.GetBumpName(cName);
-	m_material = Device.Resources->m_textures_description.GetMaterial(cName);
+	Preload(*cName);
 }
 
-void CTexture::Load		()
+void CTexture::Preload(LPCSTR name)
+{
+	m_bumpmap = Device.Resources->m_textures_description.GetBumpName(name);
+	m_material = Device.Resources->m_textures_description.GetMaterial(name);
+}
+
+void CTexture::Load()
+{
+	Load(*cName);
+}
+
+void CTexture::Load(LPCSTR name)
 {
 	if (flags.bLoaded)
 		return; //на всякий случай.
@@ -164,8 +174,8 @@ void CTexture::Load		()
 
 	flags.bUser						= false;
 	flags.MemoryUsage				= 0;
-	if (0==stricmp(*cName,"$null"))	return;
-	if (0!=strstr(*cName,"$user$"))	{
+	if (0==stricmp(name,"$null"))	return;
+	if (0!=strstr(name,"$user$"))	{
 		flags.bUser	= true;
 		return;
 	}
@@ -174,7 +184,7 @@ void CTexture::Load		()
 #ifndef		DEDICATED_SERVER
 	// Check for OGM
 	string_path			fn;
-	if (FS.exist(fn,"$game_textures$",*cName,".ogm")){
+	if (FS.exist(fn,"$game_textures$", name,".ogm")){
 		// AVI
 		pTheora		= xr_new<CTheoraSurface>();
 		m_play_time	= 0xFFFFFFFF;
@@ -205,7 +215,7 @@ void CTexture::Load		()
 
 		}
 	} else
-	if (FS.exist(fn,"$game_textures$",*cName,".avi")){
+	if (FS.exist(fn,"$game_textures$", name,".avi")){
 		// AVI
 		pAVI = xr_new<CAviPlayerCustom>();
 
@@ -232,7 +242,7 @@ void CTexture::Load		()
 
 		}
 	} else
-    if (FS.exist(fn,"$game_textures$",*cName,".seq"))
+    if (FS.exist(fn,"$game_textures$", name,".seq"))
 	{
 		// Sequence
 		string256 buffer;
@@ -271,7 +281,7 @@ void CTexture::Load		()
 	{
 		// Normal texture
 		u32	mem  = 0;
-		pSurface = ::Render->texture_load	(*cName,mem);
+		pSurface = ::Render->texture_load	(name,mem);
 
 		// Calc memory usage and preload into vid-mem
 		if (pSurface) {

--- a/ogsr_engine/xr_3da/SH_Texture.h
+++ b/ogsr_engine/xr_3da/SH_Texture.h
@@ -48,6 +48,8 @@ public:
 
 	void								Preload			();
 	void								Load			();
+	void								Preload			(LPCSTR name);
+	void								Load			(LPCSTR name);
 	void								PostLoad		();
 	void								Unload			(void);
 //	void								Apply			(u32 dwStage);


### PR DESCRIPTION
Эксперименты показали, что менять имя текстуры плохая затея - при следующей загрузке сохранения начинаются странные ключи с **CResourceManager**, создаются копии текстур с разными именами (оригинальное и то что задали при подмене).

Переделал по другому, раз это костыль состояния, то будем просто вгружать новую текстуру без подмены имени. Так стало работать нормально, все работает после save\load и при выходе из игры не ругается. Да и скрипты для работы стали проще.

Было:
```
t:unload()
t:set_name(name)
t:load()
```
Стало:
```
t:load(name)
```