### PR TITLE
Мелкий правки 2

### DIFF
--- a/ogsr_engine/xrGame/WeaponRPG7.cpp
+++ b/ogsr_engine/xrGame/WeaponRPG7.cpp
@@ -175,3 +175,10 @@ void CWeaponRPG7::net_Import( NET_Packet& P)
 	inherited::net_Import		(P);
 	UpdateMissileVisibility		();
 }
+
+void CWeaponRPG7::PlayAnimReload()
+{
+	VERIFY(GetState() == eReload);
+	// play anim with MixIn=FALSE to avoid issue with blinking rocket during reload
+	m_pHUD->animPlay(random_anim(mhud.mhud_reload), FALSE, this, GetState());
+}

--- a/ogsr_engine/xrGame/WeaponRPG7.h
+++ b/ogsr_engine/xrGame/WeaponRPG7.h
@@ -25,6 +25,7 @@ public:
 
 			void UpdateMissileVisibility	();
 	virtual void UnloadMagazine				(bool spawn_ammo = true);
+	virtual void PlayAnimReload();
 
 	virtual void net_Import			( NET_Packet& P);				// import from server
 protected:

--- a/ogsr_engine/xrGame/ui/UICarBodyWnd.h
+++ b/ogsr_engine/xrGame/ui/UICarBodyWnd.h
@@ -82,8 +82,8 @@ protected:
 
 	// Взять все
 	void					TakeAll						();
-	bool					MoveItem					(CUICellItem * itm);
-	void					MoveItemsfromCell			(bool b_all);
+	void					MoveItem					(CUICellItem* itm);
+	void					MoveItems					(CUICellItem* itm, bool b_all);
 	void					DropItemsfromCell			(bool b_all);
 
 

--- a/ogsr_engine/xrGame/ui/UITradeWnd.cpp
+++ b/ogsr_engine/xrGame/ui/UITradeWnd.cpp
@@ -232,7 +232,7 @@ void CUITradeWnd::SendMessage(CUIWindow *pWnd, s16 msg, void *pData)
 					void* d = m_pUIPropertiesBox->GetClickedItem()->GetData();
 					bool b_all = (d == (void*)33);
 
-					MoveItemsfromCell(b_all);
+					MoveItems(CurrentItem(), b_all);
 				}break;
 			}
 		}
@@ -657,7 +657,14 @@ bool CUITradeWnd::OnItemDrop(CUICellItem* itm)
 	if(old_owner==new_owner || !old_owner || !new_owner)
 		return false;
 
-	return MoveItem(itm);
+	if (Level().IR_GetKeyState(DIK_LSHIFT)) {
+		MoveItems(itm, true);
+	}
+	else {
+		MoveItem(itm);
+	}
+
+	return true;
 }
 
 bool CUITradeWnd::OnItemDbClick(CUICellItem* itm)
@@ -665,32 +672,29 @@ bool CUITradeWnd::OnItemDbClick(CUICellItem* itm)
 	SetCurrentItem						(itm);
 
 	if (Level().IR_GetKeyState(DIK_LSHIFT)) {
-		MoveItemsfromCell(true);
+		MoveItems(itm, true);
 	}
 	else {
-		if (!MoveItem(itm))
-			R_ASSERT2(false, "wrong parent for cell item");
+		MoveItem(itm);
 	}
 
 	return true;
 }
 
-void CUITradeWnd::MoveItemsfromCell(bool b_all)
+void CUITradeWnd::MoveItems(CUICellItem* itm, bool b_all)
 {
-	CUICellItem* cur_item = CurrentItem();
-
-	if (!cur_item) 
+	if (!itm)
 	{
 		return;
 	}
 
 	if (b_all)
 	{
-		u32 cnt = cur_item->ChildsCount();
+		u32 cnt = itm->ChildsCount();
 
 		//Msg("Move all items %d", cnt);
 
-		CUIDragDropListEx* old_owner = cur_item->OwnerList();
+		CUIDragDropListEx* old_owner = itm->OwnerList();
 		CUIDragDropListEx* to = nullptr;
 
 		if (old_owner == &m_uidata->UIOurBagList)
@@ -706,16 +710,15 @@ void CUITradeWnd::MoveItemsfromCell(bool b_all)
 
 		for (u32 i = 0; i < cnt; ++i) 
 		{
-			CUICellItem* itm = cur_item->PopChild();
+			CUICellItem* child_itm = itm->PopChild();
 
 			//Msg("MoveAllItems child ... %d", i);
 
-			to->SetItem(itm);
+			to->SetItem(child_itm);
 		}
 	}
 
-	MoveItem(cur_item);
-	SetCurrentItem(NULL);
+	MoveItem(itm);
 }
 
 bool CUITradeWnd::MoveItem(CUICellItem* itm) 

--- a/ogsr_engine/xrGame/ui/UITradeWnd.h
+++ b/ogsr_engine/xrGame/ui/UITradeWnd.h
@@ -59,8 +59,8 @@ protected:
 	void				PerformTrade				();
 	void				UpdatePrices				();
 	void				ColorizeItem				(CUICellItem* itm, bool canTrade, bool highlighted);
-	bool				MoveItem					(CUICellItem * itm);
-	void				MoveItemsfromCell			(bool b_all);
+	bool				MoveItem					(CUICellItem* itm);
+	void				MoveItems					(CUICellItem* itm, bool b_all);
 
 	enum EListType{eNone,e1st,e2nd,eBoth};
 

--- a/ogsr_engine/xrGame/weaponBM16.cpp
+++ b/ogsr_engine/xrGame/weaponBM16.cpp
@@ -12,16 +12,39 @@ void CWeaponBM16::Load	(LPCSTR section)
 	inherited::Load		(section);
 
 	animGetEx( mhud_reload1,      "anim_reload_1" );
+
 	animGetEx( mhud_shot1,        "anim_shoot_1" );
+	animGetEx( mhud_shot2,	pSettings->line_exist(hud_sect.c_str(), "anim_shoot_2") ? "anim_shoot_2"
+		: "anim_shoot");
+
 	animGetEx( mhud_idle1,        "anim_idle_1" );
 	animGetEx( mhud_idle2,        "anim_idle_2" );
-	animGetEx( mhud_zoomed_idle1, "anim_zoomed_idle_1" );
-	animGetEx( mhud_zoomed_idle2,  "anim_zoomedidle_2" );
 
-	animGetEx( mhud_idle_sprint_1, pSettings->line_exist( hud_sect.c_str(), "anim_idle_sprint_1" ) ? "anim_idle_sprint_1" : pSettings->line_exist( hud_sect.c_str(), "anim_idle_sprint" ) ? "anim_idle_sprint" : "anim_idle" );
-	animGetEx( mhud_idle_sprint_2, pSettings->line_exist( hud_sect.c_str(), "anim_idle_sprint_2" ) ? "anim_idle_sprint_2" : pSettings->line_exist( hud_sect.c_str(), "anim_idle_sprint" ) ? "anim_idle_sprint" : "anim_idle" );
-	animGetEx( mhud_idle_moving_1, pSettings->line_exist( hud_sect.c_str(), "anim_idle_moving_1" ) ? "anim_idle_moving_1" : pSettings->line_exist( hud_sect.c_str(), "anim_idle_moving" ) ? "anim_idle_moving" : "anim_idle" );
-	animGetEx( mhud_idle_moving_2, pSettings->line_exist( hud_sect.c_str(), "anim_idle_moving_2" ) ? "anim_idle_moving_2" : pSettings->line_exist( hud_sect.c_str(), "anim_idle_moving" ) ? "anim_idle_moving" : "anim_idle" );
+	animGetEx( mhud_zoomed_idle1, "anim_zoomed_idle_1" );
+
+	// что бы можно было нормальные имена в конфигах юзать
+	if (pSettings->line_exist(hud_sect.c_str(), "anim_zoomed_idle_2"))
+		animGetEx( mhud_zoomed_idle2, "anim_zoomed_idle_2" );
+	else
+		animGetEx(mhud_zoomed_idle2, "anim_zoomedidle_2");
+
+	animGetEx( mhud_idle_sprint_1, pSettings->line_exist( hud_sect.c_str(), "anim_idle_sprint_1" ) ? "anim_idle_sprint_1" 
+		: "anim_idle_1" );
+	animGetEx( mhud_idle_sprint_2, pSettings->line_exist( hud_sect.c_str(), "anim_idle_sprint_2" ) ? "anim_idle_sprint_2" 
+		: "anim_idle_2" );
+	animGetEx( mhud_idle_moving_1, pSettings->line_exist( hud_sect.c_str(), "anim_idle_moving_1" ) ? "anim_idle_moving_1" 
+		: "anim_idle_1" );
+	animGetEx( mhud_idle_moving_2, pSettings->line_exist( hud_sect.c_str(), "anim_idle_moving_2" ) ? "anim_idle_moving_2" 
+		: "anim_idle_2" );
+
+	animGetEx(mhud_show1, pSettings->line_exist(hud_sect.c_str(), "anim_draw_1") ? "anim_draw_1"
+		: "anim_draw");
+	animGetEx(mhud_show2, pSettings->line_exist(hud_sect.c_str(), "anim_draw_2") ? "anim_draw_2"
+		: "anim_draw");
+	animGetEx(mhud_hide1, pSettings->line_exist(hud_sect.c_str(), "anim_holster_1") ? "anim_holster_1"
+		: "anim_holster");
+	animGetEx(mhud_hide2, pSettings->line_exist(hud_sect.c_str(), "anim_holster_2") ? "anim_holster_2"
+		: "anim_holster");
 
 	HUD_SOUND::LoadSound(section, "snd_reload_1", m_sndReload1, m_eSoundShot);
 }
@@ -34,10 +57,12 @@ void CWeaponBM16::PlayReloadSound()
 
 void CWeaponBM16::PlayAnimShoot()
 {
-	if(m_magazine.size()==1)
-		m_pHUD->animPlay(random_anim(mhud_shot1),TRUE,this,GetState());
+	if (m_magazine.size() == 2)
+		m_pHUD->animPlay(random_anim(mhud_shot2), TRUE, this, GetState());
+	else if(m_magazine.size()==1)
+		m_pHUD->animPlay(random_anim(mhud_shot1),TRUE, this, GetState());
 	else
-		m_pHUD->animPlay(random_anim(mhud.mhud_shots),TRUE,this,GetState());
+		m_pHUD->animPlay(random_anim(mhud.mhud_shots),TRUE, this, GetState());
 }
 
 void CWeaponBM16::PlayAnimReload()
@@ -50,6 +75,42 @@ void CWeaponBM16::PlayAnimReload()
 	else
 		m_pHUD->animPlay(random_anim(mhud.mhud_reload),TRUE,this,GetState());
 
+}
+
+void CWeaponBM16::PlayAnimShow()
+{
+	VERIFY(GetState() == eShowing);
+
+	switch (m_magazine.size())
+	{
+	case 0: {
+		m_pHUD->animPlay(random_anim(mhud.mhud_show), FALSE, this, GetState());
+	}break;
+	case 1: {
+		m_pHUD->animPlay(random_anim(mhud_show1), FALSE, this, GetState());
+	}break;
+	case 2: {
+		m_pHUD->animPlay(random_anim(mhud_show2), FALSE, this, GetState());
+	}break;
+	};
+}
+
+void CWeaponBM16::PlayAnimHide()
+{
+	VERIFY(GetState() == eHiding);
+
+	switch (m_magazine.size())
+	{
+	case 0: {
+		m_pHUD->animPlay(random_anim(mhud.mhud_hide), TRUE, this, GetState());
+	}break;
+	case 1: {
+		m_pHUD->animPlay(random_anim(mhud_hide1), TRUE, this, GetState());
+	}break;
+	case 2: {
+		m_pHUD->animPlay(random_anim(mhud_hide2), TRUE, this, GetState());
+	}break;
+	};
 }
 
 void CWeaponBM16::PlayAnimIdle( u8 state = eIdle ) {

--- a/ogsr_engine/xrGame/weaponBM16.h
+++ b/ogsr_engine/xrGame/weaponBM16.h
@@ -9,15 +9,21 @@ class CWeaponBM16 :public CWeaponShotgun
 protected:
 	MotionSVec		mhud_reload1;
 	MotionSVec		mhud_shot1;
+	MotionSVec		mhud_shot2;
 	MotionSVec		mhud_idle1;
 	MotionSVec		mhud_idle2;
-	MotionSVec		mhud_idle_zoomed_empty;
 	MotionSVec		mhud_zoomed_idle1;
 	MotionSVec		mhud_zoomed_idle2;
 	MotionSVec		mhud_idle_sprint_1;
 	MotionSVec		mhud_idle_sprint_2;
 	MotionSVec		mhud_idle_moving_1;
 	MotionSVec		mhud_idle_moving_2;
+
+	MotionSVec		mhud_show1;
+	MotionSVec		mhud_show2;
+
+	MotionSVec		mhud_hide1;
+	MotionSVec		mhud_hide2;
 
 	HUD_SOUND		m_sndReload1;
 
@@ -29,6 +35,8 @@ protected:
 	virtual bool	TryPlayAnimIdle					( u8 );
 	virtual void	PlayAnimShoot					();
 	virtual void	PlayAnimReload					();
+	virtual void	PlayAnimShow();
+	virtual void	PlayAnimHide();
 	virtual void	PlayReloadSound					();
 	virtual void	PlayAnimIdle					( u8 );
 


### PR DESCRIPTION
* Исправлен баг с появление на доли секунды заряда при перезарядке у РПГ7 (из xrOxygen)
* Привел в порядок код в trade/car_body wnd для перемещения пачек предметов. И добавил перенос пачек перетягиванием при зажатом Shift
* Уточнения по анимации для класса BM16:
1. Для улучшения совместимости с ванильными конфигами, при отсутствии **anim_idle_sprint_1-2/anim_idle_moving_1-2** будут браться **anim_idle_1-2** соответственно, они были обязательные для этого класса с самого начала. Но все равно в чистом ТЧ нету анимации спринта с закрытыми курками - будет постоянно открывать их при спринте.
2. Добавил анимации **anim_shoot_2, anim_draw_1-2, anim_holster_1-2** из ЗП. Теперь почти все анимации ЗП поддерживаются.
3. Вместо **anim_zoomedidle_2** можно писать нормальный **anim_zoomed_idle_2**. Да это костыль, но эта опечатка вечно мешает в конфига копаться. 
По BM16, в НА есть модель со всеми этими анимациями.