### PR TITLE
Работа по UI

### DIFF
--- a/ogsr_engine/xrGame/script_actor.cpp
+++ b/ogsr_engine/xrGame/script_actor.cpp
@@ -105,6 +105,7 @@ void CScriptActor::script_register(lua_State *L)
 			.def_readwrite("satiety",					&CActorCondition::m_fSatiety)
 			.def_readwrite("satiety_v",					&CActorCondition::m_fV_Satiety)
 			.def_readwrite("satiety_health_v",			&CActorCondition::m_fV_SatietyHealth)			
+			.def_readwrite("satiety_power_v",			&CActorCondition::m_fV_SatietyPower)			
 		
 			.def_readwrite("max_power_leak_speed",		&CActorCondition::m_fPowerLeakSpeed)			
 			.def_readwrite("jump_power",				&CActorCondition::m_fJumpPower)

--- a/ogsr_engine/xrGame/ui/UICustomEdit.cpp
+++ b/ogsr_engine/xrGame/ui/UICustomEdit.cpp
@@ -1,4 +1,4 @@
-#include "StdAfx.h"
+#include "stdafx.h"
 #include <dinput.h>
 #include "../HUDManager.h"
 #include "UICustomEdit.h"
@@ -175,6 +175,11 @@ bool CUICustomEdit::OnKeyboard(int dik, EUIMessages keyboard_action)
 	return false;
 }
 
+bool CUICustomEdit::OnKeyboardHold(int dik)
+{
+  return true;
+}
+
 bool CUICustomEdit::KeyPressed(int dik)
 {
 	char out_me = 0;
@@ -310,16 +315,16 @@ void CUICustomEdit::AddChar(CHAR c)
 
 //время для обеспечивания печатания
 //символа при удерживаемой кнопке
-#define HOLD_WAIT_TIME 400
-#define HOLD_REPEAT_TIME 100
+#define HOLD_WAIT_TIME 300
+#define HOLD_REPEAT_TIME 50
 
 void CUICustomEdit::Update()
 {
 	if(m_bInputFocus)
 	{	
-		static u32 last_time; 
+    static u32 last_time;
 
-		u32 cur_time = Device.TimerAsync();
+    u32 cur_time = GetTickCount();
 
 		if(m_iKeyPressAndHold)
 		{

--- a/ogsr_engine/xrGame/ui/UICustomEdit.h
+++ b/ogsr_engine/xrGame/ui/UICustomEdit.h
@@ -46,6 +46,7 @@ public:
 
 	virtual bool	OnMouse			(float x, float y, EUIMessages mouse_action);
 	virtual bool	OnKeyboard		(int dik, EUIMessages keyboard_action);
+  virtual bool  OnKeyboardHold(int dik);
 	virtual void	OnFocusLost		();
 
 	virtual void	Update			();

--- a/ogsr_engine/xrGame/ui/UICustomEdit.h
+++ b/ogsr_engine/xrGame/ui/UICustomEdit.h
@@ -46,7 +46,7 @@ public:
 
 	virtual bool	OnMouse			(float x, float y, EUIMessages mouse_action);
 	virtual bool	OnKeyboard		(int dik, EUIMessages keyboard_action);
-	virtual bool  OnKeyboardHold(int dik);
+	virtual bool	OnKeyboardHold(int dik);
 	virtual void	OnFocusLost		();
 
 	virtual void	Update			();

--- a/ogsr_engine/xrGame/ui/UICustomEdit.h
+++ b/ogsr_engine/xrGame/ui/UICustomEdit.h
@@ -46,7 +46,7 @@ public:
 
 	virtual bool	OnMouse			(float x, float y, EUIMessages mouse_action);
 	virtual bool	OnKeyboard		(int dik, EUIMessages keyboard_action);
-  virtual bool  OnKeyboardHold(int dik);
+	virtual bool  OnKeyboardHold(int dik);
 	virtual void	OnFocusLost		();
 
 	virtual void	Update			();

--- a/ogsr_engine/xrGame/ui/UIMapWnd.cpp
+++ b/ogsr_engine/xrGame/ui/UIMapWnd.cpp
@@ -335,6 +335,8 @@ void CUIMapWnd::Draw()
 
 bool CUIMapWnd::OnKeyboardHold(int dik)
 {
+  if (inherited::OnKeyboardHold(dik)) return true;
+
 	switch(dik){
 		case DIK_UP:
 		case DIK_DOWN:
@@ -359,6 +361,8 @@ bool CUIMapWnd::OnKeyboardHold(int dik)
 
 bool CUIMapWnd::OnKeyboard				(int dik, EUIMessages keyboard_action)
 {
+  if (inherited::OnKeyboard(dik, keyboard_action)) return true;
+
 	switch(dik){
 		case DIK_NUMPADMINUS:
 			{
@@ -373,8 +377,6 @@ bool CUIMapWnd::OnKeyboard				(int dik, EUIMessages keyboard_action)
 				return true;
 			}break;
 	}
-	
-	return inherited::OnKeyboard	(dik, keyboard_action);
 }
 
 bool CUIMapWnd::OnMouse(float x, float y, EUIMessages mouse_action)

--- a/ogsr_engine/xrGame/ui/UIMapWndActions.cpp
+++ b/ogsr_engine/xrGame/ui/UIMapWndActions.cpp
@@ -5,7 +5,7 @@
 #include "UIMapWnd.h"
 
 typedef CActionBase<CUIMapWnd>				WORLD_OPERATOR;
-static const float	map_resize_speed		= 350.f;	// y.e./sec
+static const float	map_resize_speed		= 650.f;	// y.e./sec
 static const float	map_zoom_time			= 0.5f;		// sec
 static const float	min_move_time			= 0.25f;	// sec
 //actions

--- a/ogsr_engine/xrGame/ui/UIPdaSpot.cpp
+++ b/ogsr_engine/xrGame/ui/UIPdaSpot.cpp
@@ -36,6 +36,8 @@ void CUIPdaSpot::Init(u16 spot_id, LPCSTR level_name, Fvector pos, bool main_wnd
 		m_editBox->SetText(ml->GetHint());
 		ml->HighlightSpot(true, Fcolor().set(255.f, 36.f, 0.f, 255.f));
 	}
+
+  m_editBox->CaptureFocus(true);
 }
 
 void CUIPdaSpot::InitControls()
@@ -130,6 +132,8 @@ void CUIPdaSpot::Exit()
 
 bool CUIPdaSpot::OnKeyboard(int dik, EUIMessages keyboard_action)
 {
+  if (base_class::OnKeyboard(dik, keyboard_action)) return true;
+
 	switch (dik)
 	{
 	case DIK_RETURN:
@@ -149,8 +153,7 @@ bool CUIPdaSpot::OnKeyboard(int dik, EUIMessages keyboard_action)
 		}
 	}break;
 	}
-
-	return base_class::OnKeyboard(dik, keyboard_action);
+	
 }
 
 void CUIPdaSpot::SendMessage(CUIWindow* pWnd, s16 msg, void* pData)

--- a/ogsr_engine/xrGame/ui/UIPdaWnd.cpp
+++ b/ogsr_engine/xrGame/ui/UIPdaWnd.cpp
@@ -399,6 +399,3 @@ void RearrangeTabButtons(CUITabControl* pTab, xr_vector<Fvector2>& vec_sign_plac
 	}
 
 }
-
-//Чтобы нельзя было двигаться при вводе текста метки в ПДА. Другого способа не придумал.
-bool CUIPdaWnd::StopAnyMove() { return this->UIMapWnd->m_UserSpotWnd->IsShown(); }

--- a/ogsr_engine/xrGame/ui/UIPdaWnd.h
+++ b/ogsr_engine/xrGame/ui/UIPdaWnd.h
@@ -70,7 +70,7 @@ public:
 	virtual bool			OnMouse				(float x, float y, EUIMessages mouse_action) {CUIDialogWnd::OnMouse(x,y,mouse_action);return true;} //always true because StopAnyMove() == false
 	
 	void					SetActiveSubdialog	(EPdaTabs section);
-	virtual bool			StopAnyMove			();
+	virtual bool			StopAnyMove			() { return false; }
 
 			void			PdaContentsChanged	( pda_section::part type, bool = true );
 };


### PR DESCRIPTION
Work on UICustomEdit:
* Fixed issues with focus capture (for PDA mainly)
* Smaller wait time for auto repeat of character when hold button
* Now auto repeat will work in edit box when game on pause
Work on PDA:
* Auto focus pda spot name control evert time on open
* Increate speed of animation when use map in PDA
Extract m_fV_SatietyPower into scirpt with name satiety_power_v